### PR TITLE
disable metrics and discovery service for tests

### DIFF
--- a/src/main/java/tech/jhipster/controlcenter/security/jwt/TokenProvider.java
+++ b/src/main/java/tech/jhipster/controlcenter/security/jwt/TokenProvider.java
@@ -82,8 +82,9 @@ public class TokenProvider {
     }
 
     public Authentication getAuthentication(String token) {
-        Claims claims = Jwts.parser()
+        Claims claims = Jwts.parserBuilder()
             .setSigningKey(key)
+            .build()
             .parseClaimsJws(token)
             .getBody();
 
@@ -99,7 +100,7 @@ public class TokenProvider {
 
     public boolean validateToken(String authToken) {
         try {
-            Jwts.parser().setSigningKey(key).parseClaimsJws(authToken);
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(authToken);
             return true;
         } catch (JwtException | IllegalArgumentException e) {
             log.info("Invalid JWT token.");

--- a/src/test/java/tech/jhipster/controlcenter/web/rest/AccountResourceIT.java
+++ b/src/test/java/tech/jhipster/controlcenter/web/rest/AccountResourceIT.java
@@ -2,7 +2,6 @@ package tech.jhipster.controlcenter.web.rest;
 
 import tech.jhipster.controlcenter.JhipsterControlCenterApp;
 import tech.jhipster.controlcenter.security.AuthoritiesConstants;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
@@ -31,7 +30,7 @@ public class AccountResourceIT {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .expectStatus().isOk()
-            .expectHeader().contentType(MediaType.APPLICATION_JSON_UTF8)
+            .expectHeader().contentType(MediaType.APPLICATION_JSON)
             .expectBody()
             .jsonPath("$.login").isEqualTo(TEST_USER_LOGIN)
             .jsonPath("$.authorities").isEqualTo(AuthoritiesConstants.ADMIN);

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -45,6 +45,9 @@ spring:
         size: 1
   thymeleaf:
     mode: HTML
+  cloud:
+    discovery:
+      enabled: false
 
 server:
   port: 10344
@@ -76,7 +79,7 @@ jhipster:
         token-validity-in-seconds: 86400
   metrics:
     logs: # Reports metrics in the logs
-      enabled: true
+      enabled: false
       report-frequency: 60 # in seconds
 
 # ===================================================================


### PR DESCRIPTION
to use discovery service in tests, we should use testcontainers and eureka for example.
We can do this in custom configuration (cf. UaaTestSecurityConfiguration and UaaAuthorizationHeaderUtilIT from jhipster-registry project)

No issue, fix some tests