### PR TITLE
fix instance detail refresh

### DIFF
--- a/src/main/webapp/app/applications/instance/instance.component.ts
+++ b/src/main/webapp/app/applications/instance/instance.component.ts
@@ -25,7 +25,10 @@ export default class JhiInstance extends Vue {
   public mounted(): void {
     this.refreshService()
       .refreshReload$.pipe(takeUntil(this.unsubscribe$))
-      .subscribe(() => this.refreshInstancesData());
+      .subscribe(() => {
+        this.refreshInstancesData();
+        this.refreshInstancesRoute();
+      });
     this.refreshInstancesData();
     this.refreshInstancesRoute();
   }


### PR DESCRIPTION
Fix #69 

Instance's details were not refresh when :

- go to http://localhost:7419/applications/instances
- change refresh to 5sec
- then, start a new microservice
- the microservice will appear in the list -> OK
- click on detail -> KO

Because we need to refresh instance's details each time observable $refreshReload of refresh service call next. So, it is done in the subscribtion of $refreshReload.