### PR TITLE
Fix Syntax Problem with the Release Drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,8 +12,5 @@ jobs:
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
-        with:
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # config-name: my-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This fixes a syntax problem with the release drafter workflow which I've added earlier.

Related to https://github.com/jhipster/jhipster-control-center/issues/23