### PR TITLE
Improve api-docs management

### DIFF
--- a/.run/JHipster Control Center Back-End.run.xml
+++ b/.run/JHipster Control Center Back-End.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="JHipster Control Center Back-End" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <module name="jhipster-control-center" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="tech.jhipster.controlcenter.JhipsterControlCenterApp" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <envs>
+      <env name="SPRING_PROFILES_ACTIVE" value="dev,static,openapi-docs" />
+    </envs>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/JHipster Control Center Front-End.run.xml
+++ b/.run/JHipster Control Center Front-End.run.xml
@@ -1,0 +1,9 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="JHipster Control Center Front-End" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="start" />
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/main/webapp/swagger-ui/index.html
+++ b/src/main/webapp/swagger-ui/index.html
@@ -58,6 +58,10 @@
                                 oauth2 = true;
                             }
                         });
+                        // Remove the sample Swagger UI request body if present
+                        if (req.method === 'GET' && req.body === '{"additionalProp1":"string","additionalProp2":"string","additionalProp3":"string"}') {
+                            req.body = undefined;
+                        }
                         if (oauth2) {
                             // OAuth2
                             req.headers['X-XSRF-TOKEN'] = getCSRF();


### PR DESCRIPTION
Fix #113

- Dynamically fetch the list of available api docs from the /swagger-resources of each service
- Supports both v2 and v3 OpenAPI docs
- Supports all JHipster versions