### PR TITLE
Fix test in ExceptionTranslatorIT

### DIFF
--- a/src/test/java/tech/jhipster/controlcenter/web/rest/errors/ExceptionTranslatorIT.java
+++ b/src/test/java/tech/jhipster/controlcenter/web/rest/errors/ExceptionTranslatorIT.java
@@ -39,7 +39,7 @@ class ExceptionTranslatorIT {
             .jsonPath("$.fieldErrors.[0].field")
             .isEqualTo("test")
             .jsonPath("$.fieldErrors.[0].message")
-            .isEqualTo("must not be null");
+            .isNotEmpty();
     }
 
     @Test


### PR DESCRIPTION
As my locale is french, it failed with this message:

```
java.lang.AssertionError: JSON path "$.fieldErrors.[0].message" expected:<must not be null> but was:<ne doit pas être nul>
Expected :must not be null
Actual   :ne doit pas être nul
```

I was able to reproduce by generating a JHipster project with Webflux + noi18n