### PR TITLE
Improve render error message

### DIFF
--- a/src/main/webapp/app/applications/abstract.component.ts
+++ b/src/main/webapp/app/applications/abstract.component.ts
@@ -6,9 +6,18 @@ export default class AbstractComponent extends Vue {
 
   renderErrorMessage(): string {
     return (
-      `<div><p>Unable to reach the instance at ${this.internalError.path}</p>` +
-      '<p>Please, be sure the application is available.<p>' +
-      `<p>Error message: ${this.internalError.message}</p></div>`
+      '<div class="alert alert-info col-md-8">' +
+      `<p><strong>Unable to reach this point for instance at the path: ${this.internalError.path}</strong></p>` +
+      '<p>Please, be sure:</p>' +
+      '<ul>' +
+      '<li>the application is available</li>' +
+      '<li>if the path is a spring boot actuator endpoint, verify if the endpoint is available in application.yml' +
+      '<br><i>see property <code>management.endpoints.web.exposure.include</code></i></li>' +
+      '</ul>' +
+      '</div>' +
+      `<div class="alert alert-danger col-md-8">
+         <i>Error message: ${this.internalError.message}</i>
+       </div>`
     );
   }
 

--- a/src/main/webapp/app/applications/abstract.component.ts
+++ b/src/main/webapp/app/applications/abstract.component.ts
@@ -6,16 +6,23 @@ export default class AbstractComponent extends Vue {
 
   renderErrorMessage(): string {
     return (
-      '<div class="alert alert-info col-md-8">' +
-      `<p><strong>Unable to reach this point for instance at the path: ${this.internalError.path}</strong></p>` +
+      '<div class="alert alert-info col-md-10">' +
+      `<p><strong>Unable to reach this endpoint for instance at the path: ${this.internalError.path}</strong></p>` +
       '<p>Please, be sure:</p>' +
       '<ul>' +
       '<li>the application is available</li>' +
+      '<br>' +
+      '<li>the application has the same base64-secret as the JHipster Control Center base64-secret' +
+      '<br><i>see property <code>jhipster.security.authentication.jwt.base64-secret</code> in application-*.yml files from src/main/resources/config</i></li>' +
+      '<br>' +
+      '<li>if you use Consul or Eureka from docker image, check if they have the same base64-secret as the JHipster Control Center base64-secret' +
+      '<br><i>see property <code>jhipster.security.authentication.jwt.base64-secret</code> in application-*.yml files from src/main/docker/central-server-config</i></li>' +
+      '<br>' +
       '<li>if the path is a spring boot actuator endpoint, verify if the endpoint is available in application.yml' +
       '<br><i>see property <code>management.endpoints.web.exposure.include</code></i></li>' +
       '</ul>' +
       '</div>' +
-      `<div class="alert alert-danger col-md-8">
+      `<div class="alert alert-danger col-md-10">
          <i>Error message: ${this.internalError.message}</i>
        </div>`
     );
@@ -24,7 +31,7 @@ export default class AbstractComponent extends Vue {
   set error(error: any) {
     const data = error.response?.data;
     this.internalError = {
-      message: data?.message,
+      message: data?.message + ' - ' + data?.detail,
       path: data?.path,
     } as RequestError;
   }

--- a/src/main/webapp/app/applications/abstract.component.ts
+++ b/src/main/webapp/app/applications/abstract.component.ts
@@ -1,6 +1,9 @@
-import { Vue } from 'vue-property-decorator';
+import { Vue, Component } from 'vue-property-decorator';
 import { RequestError } from '@/shared/model/request.error.model';
 
+@Component({
+  template: '<div></div>',
+})
 export default class AbstractComponent extends Vue {
   private internalError: RequestError = null;
 
@@ -28,7 +31,7 @@ export default class AbstractComponent extends Vue {
     );
   }
 
-  set error(error: any) {
+  public setError(error: any) {
     const data = error.response?.data;
     this.internalError = {
       message: data?.message + ' - ' + data?.detail,
@@ -36,11 +39,15 @@ export default class AbstractComponent extends Vue {
     } as RequestError;
   }
 
-  get isError(): boolean {
-    return !!this.internalError;
-  }
-
   public resetError() {
     this.internalError = null;
+  }
+
+  public getError() {
+    return this.internalError;
+  }
+
+  get isError(): boolean {
+    return !!this.internalError;
   }
 }

--- a/src/main/webapp/app/applications/caches/caches.component.ts
+++ b/src/main/webapp/app/applications/caches/caches.component.ts
@@ -69,7 +69,7 @@ export default class JhiCaches extends AbstractComponent {
           this.paginate(this.page);
           this.resetError();
         },
-        error => (this.error = error)
+        error => this.setError(error)
       );
   }
 
@@ -83,7 +83,7 @@ export default class JhiCaches extends AbstractComponent {
           this.paginateMetrics(this.pageMetrics);
           this.resetError();
         },
-        error => (this.error = error)
+        error => this.setError(error)
       );
   }
 

--- a/src/main/webapp/app/applications/configuration/configuration.component.ts
+++ b/src/main/webapp/app/applications/configuration/configuration.component.ts
@@ -55,7 +55,7 @@ export default class JhiConfiguration extends AbstractComponent {
             this.resetError();
           },
           error => {
-            this.error = error;
+            this.setError(error);
           }
         );
 
@@ -67,7 +67,7 @@ export default class JhiConfiguration extends AbstractComponent {
             this.propertySources = propertySources;
             this.resetError();
           },
-          error => (this.error = error)
+          error => this.setError(error)
         );
     } else {
       this.routesService().routeDown(this.activeRoute);

--- a/src/main/webapp/app/applications/health/health.component.ts
+++ b/src/main/webapp/app/applications/health/health.component.ts
@@ -1,9 +1,8 @@
 import JhiHealthModal from './health-modal.vue';
-import { Component, Inject, Vue } from 'vue-property-decorator';
+import { Component, Inject } from 'vue-property-decorator';
 import RoutesSelectorVue from '@/shared/routes/routes-selector.vue';
 import RoutesService, { Route } from '@/shared/routes/routes.service';
 import { Subject } from 'rxjs';
-import { RefreshService } from '@/shared/refresh/refresh.service';
 import { takeUntil } from 'rxjs/operators';
 import InstanceHealthService from './health.service';
 import AbstractComponent from '@/applications/abstract.component';
@@ -47,7 +46,7 @@ export default class JhiInstanceHealth extends AbstractComponent {
           this.healthData = this.instanceHealthService().transformHealthData(health);
           this.resetError();
         },
-        error => (this.error = error)
+        error => this.setError(error)
       );
   }
 

--- a/src/main/webapp/app/applications/logfile/logfile.component.ts
+++ b/src/main/webapp/app/applications/logfile/logfile.component.ts
@@ -62,7 +62,7 @@ export default class JhiLogfile extends AbstractComponent {
                 '- https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html\n ' +
                 '- https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html';
             } else {
-              this.error = error;
+              this.setError(error);
             }
           }
         );

--- a/src/main/webapp/app/applications/loggers/loggers.component.ts
+++ b/src/main/webapp/app/applications/loggers/loggers.component.ts
@@ -67,7 +67,7 @@ export default class JhiLoggers extends AbstractComponent {
           this.loggers = res;
           this.resetError();
         },
-        error => (this.error = error)
+        error => this.setError(error)
       );
   }
 

--- a/src/main/webapp/app/applications/metric/metric.component.ts
+++ b/src/main/webapp/app/applications/metric/metric.component.ts
@@ -1,4 +1,4 @@
-import { Component, Vue, Inject } from 'vue-property-decorator';
+import { Component, Inject } from 'vue-property-decorator';
 import numeral from 'numeral';
 import JhiMetricModal from './metric-modal.vue';
 import MetricService, { Metrics, ThreadDump } from './metric.service';
@@ -61,7 +61,10 @@ export default class JhiMetric extends AbstractComponent {
         () => {
           this.resetError();
         },
-        error => (this.error = error)
+        error => {
+          console.log('MYERROR ' + error);
+          this.setError(error);
+        }
       );
   }
 

--- a/src/test/javascript/spec/app/applications/abstract.component.spec.ts
+++ b/src/test/javascript/spec/app/applications/abstract.component.spec.ts
@@ -1,0 +1,66 @@
+import AbstractComponent from '@/applications/abstract.component';
+import { createLocalVue, shallowMount, Wrapper } from '@vue/test-utils';
+import { error_abstract_component } from '../../fixtures/jhcc.fixtures';
+
+const localVue = createLocalVue();
+
+describe('abstract component', () => {
+  let wrapper: Wrapper<AbstractComponent>;
+  let abstractComponent: AbstractComponent;
+
+  beforeEach(async () => {
+    wrapper = shallowMount<AbstractComponent>(AbstractComponent, {
+      localVue,
+    });
+    abstractComponent = wrapper.vm;
+    await abstractComponent.$nextTick();
+  });
+
+  it('should set error', async () => {
+    abstractComponent.setError(error_abstract_component);
+    const expectedPath = 'generic/path';
+    const expectedMessage = 'generic message - generic detail';
+    abstractComponent.setError(error_abstract_component);
+    expect(abstractComponent.getError().path).toEqual(expectedPath);
+    expect(abstractComponent.getError().message).toEqual(expectedMessage);
+  });
+
+  it('should reset error', async () => {
+    abstractComponent.setError(error_abstract_component);
+    expect(abstractComponent.isError).toBeTruthy();
+    abstractComponent.resetError();
+    expect(abstractComponent.isError).toBeFalsy();
+  });
+
+  it('should render error', async () => {
+    abstractComponent.setError(error_abstract_component);
+    const expectedPath = 'generic/path';
+    const expectedMessage = 'generic message - generic detail';
+    const expectedRender =
+      '<div class="alert alert-info col-md-10">' +
+      `<p><strong>Unable to reach this endpoint for instance at the path: ` +
+      expectedPath +
+      `</strong></p>` +
+      '<p>Please, be sure:</p>' +
+      '<ul>' +
+      '<li>the application is available</li>' +
+      '<br>' +
+      '<li>the application has the same base64-secret as the JHipster Control Center base64-secret' +
+      '<br><i>see property <code>jhipster.security.authentication.jwt.base64-secret</code> in application-*.yml files from src/main/resources/config</i></li>' +
+      '<br>' +
+      '<li>if you use Consul or Eureka from docker image, check if they have the same base64-secret as the JHipster Control Center base64-secret' +
+      '<br><i>see property <code>jhipster.security.authentication.jwt.base64-secret</code> in application-*.yml files from src/main/docker/central-server-config</i></li>' +
+      '<br>' +
+      '<li>if the path is a spring boot actuator endpoint, verify if the endpoint is available in application.yml' +
+      '<br><i>see property <code>management.endpoints.web.exposure.include</code></i></li>' +
+      '</ul>' +
+      '</div>' +
+      `<div class="alert alert-danger col-md-10">
+         <i>Error message: ` +
+      expectedMessage +
+      `</i>
+       </div>`;
+    const result: string = abstractComponent.renderErrorMessage();
+    expect(result).toEqual(expectedRender);
+  });
+});

--- a/src/test/javascript/spec/app/applications/logfile/logfile.component.spec.ts
+++ b/src/test/javascript/spec/app/applications/logfile/logfile.component.spec.ts
@@ -1,4 +1,4 @@
-import { shallowMount, createLocalVue, Wrapper, mount } from '@vue/test-utils';
+import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils';
 import * as config from '@/shared/config/config';
 import axios from 'axios';
 import RoutesService from '@/shared/routes/routes.service';
@@ -108,11 +108,11 @@ describe('Logfile Component', () => {
     logfile.activeRoute = jhcc_route;
     const spy = jest
       .spyOn(logfileService, 'findLogfile')
-      .mockReturnValue(throwError({ response: { status: 400 }, message: 'Bad Request' }));
+      .mockReturnValue(throwError({ response: { data: { message: '400 Bad Request', detail: 'description' } } }));
     logfile.refreshActiveRouteLog();
     await logfile.$nextTick();
     expect(spy).toHaveBeenCalled();
-    expect(logfile.error).toStrictEqual({ response: { status: 400 }, message: 'Bad Request' });
+    expect(logfile.getError().message).toStrictEqual('400 Bad Request - description');
     spy.mockRestore();
   });
 

--- a/src/test/javascript/spec/app/applications/metric/metric.component.spec.ts
+++ b/src/test/javascript/spec/app/applications/metric/metric.component.spec.ts
@@ -10,7 +10,7 @@ import RoutesService from '@/shared/routes/routes.service';
 import { RefreshService } from '@/shared/refresh/refresh.service';
 import { BootstrapVue } from 'bootstrap-vue';
 import { Observable } from 'rxjs';
-import { jhcc_metrics, jhcc_route } from '../../../fixtures/jhcc.fixtures';
+import { jhcc_metrics, jhcc_route, jhcc_threadDump } from '../../../fixtures/jhcc.fixtures';
 
 const localVue = createLocalVue();
 localVue.component('font-awesome-icon', FontAwesomeIcon);
@@ -38,8 +38,9 @@ describe('Metrics Component', () => {
   let wrapper: Wrapper<MetricClass>;
   let metricComponent: MetricClass;
 
-  beforeEach(() => {
-    mockedAxios.get.mockReturnValue(Promise.resolve({ data: { timers: [], gauges: [] } }));
+  beforeEach(async () => {
+    mockedAxios.get.mockReturnValueOnce(Promise.resolve({ data: jhcc_metrics }));
+    mockedAxios.get.mockReturnValueOnce(Promise.resolve({ data: jhcc_threadDump }));
     wrapper = shallowMount<MetricClass>(Metric, {
       store,
       localVue,
@@ -58,10 +59,12 @@ describe('Metrics Component', () => {
       },
     });
     metricComponent = wrapper.vm;
+    await metricComponent.$nextTick();
   });
 
   it('when component is mounted', async () => {
-    mockedAxios.get.mockReturnValue(Promise.resolve({ data: jhcc_metrics }));
+    mockedAxios.get.mockReturnValueOnce(Promise.resolve({ data: jhcc_metrics }));
+    mockedAxios.get.mockReturnValueOnce(Promise.resolve({ data: jhcc_threadDump }));
     const subscribeRouteChanged = jest.spyOn(routesService.routeChanged$, 'subscribe');
     const wrapperToTestMounted = shallowMount<MetricClass>(Metric, {
       store,
@@ -104,8 +107,8 @@ describe('Metrics Component', () => {
 
   describe('show threads data', () => {
     it('should show modal which contains threads data', () => {
-      const spy = jest.spyOn(<any>metricComponent.$refs.metricsModal, 'show');
       metricComponent.activeRoute = jhcc_route;
+      const spy = jest.spyOn(<any>metricComponent.$refs.metricsModal, 'show');
       metricComponent.openModal();
       expect(spy).toHaveBeenCalled();
     });

--- a/src/test/javascript/spec/fixtures/jhcc.fixtures.ts
+++ b/src/test/javascript/spec/fixtures/jhcc.fixtures.ts
@@ -2,7 +2,18 @@ import { Route } from '@/shared/routes/routes.service';
 import { Bean, PropertySource } from '@/applications/configuration/configuration.service';
 import { Instance } from '@/applications/instance/instance.service';
 import { Log } from '@/applications/loggers/loggers.service';
-import CachesService, { Cache } from '@/applications/caches/caches.service';
+import CachesService from '@/applications/caches/caches.service';
+import { ThreadDump } from '@/applications/metric/metric.service';
+
+const error_abstract_component = {
+  response: {
+    data: {
+      message: 'generic message',
+      detail: 'generic detail',
+      path: 'generic/path',
+    },
+  },
+};
 
 const stubbedModal = {
   template: '<div></div>',
@@ -388,6 +399,15 @@ const jhcc_metrics = {
   ],
 };
 
+const jhcc_threadDump: ThreadDump = {
+  threads: [
+    { name: 'test1', threadState: 'RUNNABLE' },
+    { name: 'test2', threadState: 'WAITING' },
+    { name: 'test3', threadState: 'TIMED_WAITING' },
+    { name: 'test4', threadState: 'BLOCKED' },
+  ],
+};
+
 const jhcc_metrics_caches = CachesService.parseJsonToArrayOfCacheMetrics(jhcc_metrics['cache']);
 
 const jhcc_caches_json = {
@@ -407,6 +427,7 @@ const jhcc_caches_json = {
 const jhcc_caches = CachesService.parseJsonToArrayOfCache(jhcc_caches_json);
 
 export {
+  error_abstract_component,
   stubbedModal,
   inst,
   instanceList,
@@ -428,6 +449,7 @@ export {
   jhcc_logfile_error,
   jhcc_logs,
   jhcc_metrics,
+  jhcc_threadDump,
   jhcc_metrics_caches,
   jhcc_caches_json,
   jhcc_caches,


### PR DESCRIPTION
The goal here is to improve the error messages when we can't reach an endpoint of an instance in order to help users to see what is missing.

For example,

We used to have this:
![old-error](https://user-images.githubusercontent.com/23552990/103345905-e570fd00-4a92-11eb-9ac0-00c10bd1d45d.png)

After, we can have something like this:
![new-error-2](https://user-images.githubusercontent.com/23552990/103492813-db9e1f80-4e2d-11eb-9ffe-a94eedbf9d45.png)