### PR TITLE
Swagger blank page when using static profile

### DIFF
--- a/src/main/java/tech/jhipster/controlcenter/config/apidoc/SwaggerConfiguration.java
+++ b/src/main/java/tech/jhipster/controlcenter/config/apidoc/SwaggerConfiguration.java
@@ -68,7 +68,9 @@ public class SwaggerConfiguration implements SwaggerResourcesProvider {
                         .uri("/swagger-resources")
                         .retrieve()
                         .bodyToFlux(SwaggerResource.class)
-                        .collectList();
+                        .onErrorResume(exception -> Mono.empty())
+                        .collectList()
+                        .defaultIfEmpty(Collections.emptyList());
                     return Mono.just(route).zipWith(swaggerResources);
                 }
             )
@@ -82,6 +84,7 @@ public class SwaggerConfiguration implements SwaggerResourcesProvider {
         //Add the registered microservices swagger docs as additional swagger resources
         List<SwaggerResource> servicesSwaggerResources = servicesRouteSwaggerResources
             .stream()
+            .filter(tuple -> !tuple.getT2().isEmpty())
             .map(
                 tuple -> {
                     Route route = tuple.getT1();


### PR DESCRIPTION
When we use static profile, if an instance is not running, swagger page display a blank page because it cannot retreive swagger resource of an instance that is not available.

Fix :

- return an empty list of swagger resources when an instance is not available in the flux
- filter swagger resources on instance which have swagger resources