### PR TITLE
fix: avoid OIDC discovery parsing errors

### DIFF
--- a/src/main/docker/app.yml
+++ b/src/main/docker/app.yml
@@ -21,9 +21,15 @@ services:
       - SPRING_PROFILES_ACTIVE=prod,api-docs
       - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED=true
       - JHIPSTER_SLEEP=30 # gives time for other services to boot before the application
-    #      - SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_ISSUER_URI=http://keycloak:9080/auth/realms/jhipster
+    #      - SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_AUTHORIZATION_URI=http://keycloak:9080/auth/realms/jhipster/protocol/openid-connect/auth
+    #      - SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_TOKEN_URI=http://keycloak:9080/auth/realms/jhipster/protocol/openid-connect/token
+    #      - SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_JWK_SET_URI=http://keycloak:9080/auth/realms/jhipster/protocol/openid-connect/certs
+    #      - SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_USER_INFO_URI=http://keycloak:9080/auth/realms/jhipster/protocol/openid-connect/userinfo
+    #      - SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_USER_NAME_ATTRIBUTE=preferred_username
     #      - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENT_ID=web_app
     #      - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENT_SECRET=web_app
+    #      - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI=http://keycloak:9080/auth/realms/jhipster
+    #      - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://keycloak:9080/auth/realms/jhipster/protocol/openid-connect/certs
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:

--- a/src/main/java/tech/jhipster/controlcenter/config/Oauth2SecurityConfiguration.java
+++ b/src/main/java/tech/jhipster/controlcenter/config/Oauth2SecurityConfiguration.java
@@ -28,7 +28,6 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
-import org.springframework.security.oauth2.jwt.ReactiveJwtDecoders;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter;
 import org.springframework.security.web.server.SecurityWebFilterChain;
@@ -54,8 +53,11 @@ import tech.jhipster.web.filter.reactive.CookieCsrfFilter;
 @Profile(Constants.PROFILE_OAUTH2)
 public class Oauth2SecurityConfiguration {
 
-    @Value("${spring.security.oauth2.client.provider.oidc.issuer-uri}")
+    @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuerUri;
+
+    @Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}")
+    private String jwkSetUri;
 
     private final TokenProvider tokenProvider;
 
@@ -176,7 +178,7 @@ public class Oauth2SecurityConfiguration {
 
     @Bean
     ReactiveJwtDecoder jwtDecoder() {
-        NimbusReactiveJwtDecoder jwtDecoder = (NimbusReactiveJwtDecoder) ReactiveJwtDecoders.fromOidcIssuerLocation(issuerUri);
+        NimbusReactiveJwtDecoder jwtDecoder = NimbusReactiveJwtDecoder.withJwkSetUri(jwkSetUri).build();
 
         OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(jHipsterProperties.getSecurity().getOauth2().getAudience());
         OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuerUri);

--- a/src/main/java/tech/jhipster/controlcenter/web/rest/AuthInfoResource.java
+++ b/src/main/java/tech/jhipster/controlcenter/web/rest/AuthInfoResource.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api")
 public class AuthInfoResource {
-    @Value("${spring.security.oauth2.client.provider.oidc.issuer-uri:}")
+    @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri:${spring.security.oauth2.client.provider.oidc.issuer-uri:}}")
     private String issuer;
 
     @Value("${spring.security.oauth2.client.registration.oidc.client-id:}")

--- a/src/main/resources/config/application-oauth2.yml
+++ b/src/main/resources/config/application-oauth2.yml
@@ -4,7 +4,11 @@ spring:
       client:
         provider:
           oidc:
-            issuer-uri: http://localhost:9080/auth/realms/jhipster
+            authorization-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/auth
+            token-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/token
+            jwk-set-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/certs
+            user-info-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/userinfo
+            user-name-attribute: preferred_username
         registration:
           oidc:
             client-id: web_app
@@ -13,6 +17,7 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: http://localhost:9080/auth/realms/jhipster
+          jwk-set-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/certs
   cloud:
     gateway:
       default-filters:

--- a/src/test/resources/config/application-oauth2-test.yml
+++ b/src/test/resources/config/application-oauth2-test.yml
@@ -4,7 +4,11 @@ spring:
       client:
         provider:
           oidc:
-            issuer-uri: http://localhost:9080/auth/realms/jhipster
+            authorization-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/auth
+            token-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/token
+            jwk-set-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/certs
+            user-info-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/userinfo
+            user-name-attribute: preferred_username
         registration:
           oidc:
             client-id: web_app
@@ -12,3 +16,4 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: http://localhost:9080/auth/realms/jhipster
+          jwk-set-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/certs


### PR DESCRIPTION
## Summary
- Avoid OIDC discovery parsing failures by using explicit provider endpoints
- Configure `jwk-set-uri` for the resource server JWT decoder
- Keep `issuer` exposure working for auth-info
- Update docker env var guidance for OAuth2

## Related
- Fixes jhipster/jhipster-control-center#174
