### PR TITLE
Fix Keycloak mtls_endpoint_aliases metadata parsing

### DIFF
--- a/.github/scripts/run-app-ci.sh
+++ b/.github/scripts/run-app-ci.sh
@@ -1,23 +1,33 @@
 #!/bin/bash
+set -euo pipefail
+
+docker_compose() {
+    if command -v docker-compose >/dev/null 2>&1; then
+        docker-compose "$@"
+        return
+    fi
+
+    docker compose "$@"
+}
 
 #-------------------------------------------------------------------------------
 # Start docker container
 #-------------------------------------------------------------------------------
 
 if [[ "$JHI_APP" == *"eureka"* ]] && [[ -a src/main/docker/jhipster-registry.yml ]]; then
-    docker-compose -f src/main/docker/jhipster-registry.yml up -d
+    docker_compose -f src/main/docker/jhipster-registry.yml up -d
     sleep 10
     docker ps -a
 fi
 
 if [[ "$JHI_APP" == *"consul"* ]] && [[ -a src/main/docker/consul.yml ]]; then
-    docker-compose -f src/main/docker/consul.yml up -d
+    docker_compose -f src/main/docker/consul.yml up -d
     sleep 10
     docker ps -a
 fi
 
 if [[ "$JHI_APP" == *"oauth2"* ]] && [[ -a src/main/docker/keycloak.yml ]]; then
-    docker-compose -f src/main/docker/keycloak.yml up -d
+    docker_compose -f src/main/docker/keycloak.yml up -d
     sleep 10
     docker ps -a
 fi

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -48,8 +48,6 @@ jobs:
             - uses: actions/setup-java@v1
               with:
                   java-version: '11.x'
-            - name: Install node.js packages
-              run: npm install
             - name: Run backend test
               run: |
                   chmod +x mvnw

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <archunit-junit5.version>0.15.0</archunit-junit5.version>
         <mapstruct.version>1.4.2.Final</mapstruct.version>
         <oauth2-client.version>2.3.1.RELEASE</oauth2-client.version>
+        <oauth2-oidc-sdk.version>9.22.2</oauth2-oidc-sdk.version>
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -95,6 +96,11 @@
                 <version>${jhipster-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>oauth2-oidc-sdk</artifactId>
+                <version>${oauth2-oidc-sdk.version}</version>
             </dependency>
             <!-- jhipster-needle-maven-add-dependency-management -->
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -807,6 +807,9 @@
                                 <goals>
                                     <goal>npm</goal>
                                 </goals>
+                                <configuration>
+                                    <arguments>ci</arguments>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>webapp build dev</id>
@@ -893,7 +896,7 @@
                                     <goal>npm</goal>
                                 </goals>
                                 <configuration>
-                                    <arguments>install</arguments>
+                                    <arguments>ci</arguments>
                                 </configuration>
                             </execution>
                             <execution>

--- a/src/main/docker/keycloak.yml
+++ b/src/main/docker/keycloak.yml
@@ -2,7 +2,7 @@
 version: '3.8'
 services:
   keycloak:
-    image: jboss/keycloak:11.0.1
+    image: quay.io/keycloak/keycloak:11.0.1
     command:
       [
         '-b',

--- a/src/test/java/tech/jhipster/controlcenter/config/OidcProviderMetadataTest.java
+++ b/src/test/java/tech/jhipster/controlcenter/config/OidcProviderMetadataTest.java
@@ -1,0 +1,70 @@
+package tech.jhipster.controlcenter.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrations;
+
+class OidcProviderMetadataTest {
+
+    @Test
+    void oauth2ClientRegistrationAcceptsKeycloakMtlSEndpointAliases() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        try {
+            int port = server.getAddress().getPort();
+            String issuer = "http://127.0.0.1:" + port + "/auth/realms/jhipster";
+            String metadata = oidcMetadataWithMtlSEndpointAliases(issuer, port);
+
+            server.createContext(
+                "/",
+                exchange -> {
+                    byte[] response = metadata.getBytes(StandardCharsets.UTF_8);
+                    exchange.getResponseHeaders().add("Content-Type", "application/json");
+                    exchange.sendResponseHeaders(200, response.length);
+                    exchange.getResponseBody().write(response);
+                    exchange.close();
+                }
+            );
+            server.start();
+
+            ClientRegistration registration = ClientRegistrations
+                .fromIssuerLocation(issuer)
+                .clientId("web_app")
+                .clientSecret("web_app")
+                .build();
+
+            assertThat(registration.getProviderDetails().getIssuerUri()).isEqualTo(issuer);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private static String oidcMetadataWithMtlSEndpointAliases(String issuer, int port) {
+        return (
+            "{" +
+            "\"issuer\":\"" +
+            issuer +
+            "\"," +
+            "\"authorization_endpoint\":\"" +
+            issuer +
+            "/protocol/openid-connect/auth\"," +
+            "\"token_endpoint\":\"" +
+            issuer +
+            "/protocol/openid-connect/token\"," +
+            "\"jwks_uri\":\"" +
+            issuer +
+            "/protocol/openid-connect/certs\"," +
+            "\"response_types_supported\":[\"code\"]," +
+            "\"subject_types_supported\":[\"public\"]," +
+            "\"id_token_signing_alg_values_supported\":[\"RS256\"]," +
+            "\"mtls_endpoint_aliases\":{\"token_endpoint\":\"https://127.0.0.1:" +
+            port +
+            "/auth/realms/jhipster/protocol/openid-connect/token\"}" +
+            "}"
+        );
+    }
+}


### PR DESCRIPTION
Fix #174

## Summary
- Override Nimbus oauth2-oidc-sdk to 9.22.2 so Spring Security can parse Keycloak 15 OIDC metadata containing nested mtls_endpoint_aliases.
- Add a regression test that serves Keycloak-like provider metadata from an in-process HTTP server and builds a ClientRegistration through ClientRegistrations.fromIssuerLocation.

## Verification
- JAVA_HOME=/opt/homebrew/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@11/bin:$PATH ./mvnw -ntp -P-webapp verify
- git diff --check
