### PR TITLE
Fix #174: pin com.nimbusds:oauth2-oidc-sdk to 9.43.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
         <archunit-junit5.version>0.15.0</archunit-junit5.version>
         <mapstruct.version>1.4.2.Final</mapstruct.version>
         <oauth2-client.version>2.3.1.RELEASE</oauth2-client.version>
+        <!-- Pin com.nimbusds:oauth2-oidc-sdk to a version that can parse the
+        `mtls_endpoint_aliases` field returned by Keycloak (and other modern
+        OIDC providers). The version transitively pulled by spring-security
+        5.4.x is 7.x, which fails with `Unexpected type of JSON object member
+        with key mtls_endpoint_aliases` at startup. See #174. -->
+        <oauth2-oidc-sdk.version>9.43.6</oauth2-oidc-sdk.version>
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -95,6 +101,11 @@
                 <version>${jhipster-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>oauth2-oidc-sdk</artifactId>
+                <version>${oauth2-oidc-sdk.version}</version>
             </dependency>
             <!-- jhipster-needle-maven-add-dependency-management -->
         </dependencies>

--- a/src/test/java/tech/jhipster/controlcenter/config/OidcProviderMetadataParsingTest.java
+++ b/src/test/java/tech/jhipster/controlcenter/config/OidcProviderMetadataParsingTest.java
@@ -1,0 +1,97 @@
+package tech.jhipster.controlcenter.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.sun.net.httpserver.HttpServer;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrations;
+
+/**
+ * Regression test for <a
+ * href="https://github.com/jhipster/jhipster-control-center/issues/174">#174</a>.
+ *
+ * <p>Modern Keycloak releases (and other OIDC providers) advertise an
+ * {@code mtls_endpoint_aliases} object in their discovery document. Older
+ * versions of {@code com.nimbusds:oauth2-oidc-sdk} (7.x, the version
+ * transitively brought in by spring-security 5.4.x) fail to parse that field
+ * and throw {@code ParseException: Unexpected type of JSON object member with
+ * key mtls_endpoint_aliases}, blocking the control-center from booting against
+ * Keycloak 15+.
+ *
+ * <p>The fix is the 9.x version pin in {@code pom.xml}. This test serves a
+ * minimal OIDC discovery document — populated with {@code
+ * mtls_endpoint_aliases} — from an in-process HTTP server and verifies that
+ * {@link ClientRegistrations#fromIssuerLocation(String)} parses it without
+ * throwing.
+ */
+class OidcProviderMetadataParsingTest {
+
+    @Test
+    void parsesOidcMetadataContainingMtlsEndpointAliases() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        try {
+            int port = server.getAddress().getPort();
+            String issuer = "http://127.0.0.1:" + port + "/auth/realms/jhipster";
+            String metadata = oidcDiscoveryDocument(issuer, port);
+
+            server.createContext(
+                "/",
+                exchange -> {
+                    byte[] body = metadata.getBytes(StandardCharsets.UTF_8);
+                    exchange.getResponseHeaders().add("Content-Type", "application/json");
+                    exchange.sendResponseHeaders(200, body.length);
+                    exchange.getResponseBody().write(body);
+                    exchange.close();
+                }
+            );
+            server.start();
+
+            assertThatCode(() -> {
+                ClientRegistration registration = ClientRegistrations
+                    .fromIssuerLocation(issuer)
+                    .clientId("web_app")
+                    .clientSecret("web_app")
+                    .build();
+
+                assertThat(registration.getProviderDetails().getIssuerUri()).isEqualTo(issuer);
+                assertThat(registration.getProviderDetails().getTokenUri())
+                    .isEqualTo(issuer + "/protocol/openid-connect/token");
+                assertThat(registration.getProviderDetails().getAuthorizationUri())
+                    .isEqualTo(issuer + "/protocol/openid-connect/auth");
+                assertThat(registration.getProviderDetails().getJwkSetUri())
+                    .isEqualTo(issuer + "/protocol/openid-connect/certs");
+            })
+                .doesNotThrowAnyException();
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Minimal OIDC discovery document that includes the {@code
+     * mtls_endpoint_aliases} object Keycloak advertises starting with version
+     * 15. The field must be a JSON object whose values are endpoint URIs.
+     */
+    private static String oidcDiscoveryDocument(String issuer, int port) {
+        return (
+            "{" +
+            "\"issuer\":\"" + issuer + "\"," +
+            "\"authorization_endpoint\":\"" + issuer + "/protocol/openid-connect/auth\"," +
+            "\"token_endpoint\":\"" + issuer + "/protocol/openid-connect/token\"," +
+            "\"jwks_uri\":\"" + issuer + "/protocol/openid-connect/certs\"," +
+            "\"response_types_supported\":[\"code\"]," +
+            "\"subject_types_supported\":[\"public\"]," +
+            "\"id_token_signing_alg_values_supported\":[\"RS256\"]," +
+            "\"mtls_endpoint_aliases\":{" +
+            "\"token_endpoint\":\"https://127.0.0.1:" + port + "/auth/realms/jhipster/protocol/openid-connect/token\"," +
+            "\"revocation_endpoint\":\"https://127.0.0.1:" + port + "/auth/realms/jhipster/protocol/openid-connect/revoke\"," +
+            "\"introspection_endpoint\":\"https://127.0.0.1:" + port + "/auth/realms/jhipster/protocol/openid-connect/introspect\"" +
+            "}" +
+            "}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #174.

Modern Keycloak releases (15+) advertise an `mtls_endpoint_aliases` object in their OIDC discovery document. The version of `com.nimbusds:oauth2-oidc-sdk` transitively brought in by spring-security 5.4.x is **7.x**, which throws `ParseException: Unexpected type of JSON object member with key mtls_endpoint_aliases` at startup and blocks the control-center from booting against Keycloak 15+.

The fix is a `<dependencyManagement>` override: pin **9.43.6** (the latest 9.x patch — binary-compatible with Spring 5.4.x) so the parser understands `mtls_endpoint_aliases` and the other newer metadata fields. This is the resolution multiple commenters on the issue independently reached (#174 comment thread).

## Scope (intentionally narrow)

- `pom.xml` — new `oauth2-oidc-sdk.version` property and a `<dependencyManagement>` entry pinning the version. Two hunks, eleven lines.
- `src/test/java/tech/jhipster/controlcenter/config/OidcProviderMetadataParsingTest.java` — new focused regression test. Serves a minimal OIDC discovery document populated with `mtls_endpoint_aliases` from an in-process `com.sun.net.httpserver.HttpServer` and asserts that `ClientRegistrations.fromIssuerLocation` parses it without throwing, with extra assertions on the parsed issuer/token/auth/JWKS URIs.

Deliberately does **not** touch `.github/scripts/run-app-ci.sh`, `.github/workflows/github-ci.yml`, or `src/main/docker/keycloak.yml` — those are orthogonal CI/image-name fixups handled in #194; this PR keeps the change surface to the bounty subject only, so reviewers can land the bug fix without coupling it to unrelated CI churn.

## Validation

- The new test boots an in-process HTTP server and exercises the real Spring Security `ClientRegistrations.fromIssuerLocation` parser against a discovery document that includes `mtls_endpoint_aliases`. With the old 7.x dependency it would reproduce the stack trace pasted in #174; with the 9.43.6 pin it passes.
- No production code changes — only a dependency override.
- Backward-compatible: 9.43.6 is the latest patch on the 9.x line and remains drop-in for Spring Security 5.4.x consumers.

Refs: #177 (early attempt, stale 4y), #192 (Feb 2026, no activity), #194 (active PR by @antaloaalonso that bundles this fix with three orthogonal CI/image-name changes — happy to defer to that if the maintainer prefers the broader scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)