### PR TITLE
Fix Keycloak OIDC metadata parsing with mtls_endpoint_aliases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
         <archunit-junit5.version>0.15.0</archunit-junit5.version>
         <mapstruct.version>1.4.2.Final</mapstruct.version>
         <oauth2-client.version>2.3.1.RELEASE</oauth2-client.version>
+        <nimbus-jose-jwt.version>8.21</nimbus-jose-jwt.version>
+        <oauth2-oidc-sdk.version>9.19</oauth2-oidc-sdk.version>
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -95,6 +97,16 @@
                 <version>${jhipster-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbus-jose-jwt.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>oauth2-oidc-sdk</artifactId>
+                <version>${oauth2-oidc-sdk.version}</version>
             </dependency>
             <!-- jhipster-needle-maven-add-dependency-management -->
         </dependencies>
@@ -264,6 +276,14 @@
             <artifactId>metrics-core</artifactId>
         </dependency>
         <!-- jhcc-custom -->
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>oauth2-oidc-sdk</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter</artifactId>


### PR DESCRIPTION
Fixes #174.

Aligns Nimbus OAuth2/OIDC and JOSE/JWT dependencies so Keycloak issuer metadata containing mtls_endpoint_aliases is parsed successfully.

Verification:
- ./mvnw -DskipTests dependency:tree -Dincludes=com.nimbusds passes.
- ./mvnw -P-webapp verify passes.
- Full ./mvnw verify currently fails in my local frontend build before exercising this change, due to vue-loader/webpack resolving webpack/lib/rules/DescriptionDataMatcherRulePlugin. This appears unrelated to the Nimbus dependency alignment.