### PR TITLE
fix: point the dev Keycloak at quay.io and drop the removed js authorization policy (#228)

### DIFF
--- a/src/main/docker/keycloak.yml
+++ b/src/main/docker/keycloak.yml
@@ -2,25 +2,20 @@
 version: '3.8'
 services:
   keycloak:
-    image: jboss/keycloak:11.0.1
+    image: quay.io/keycloak/keycloak:26.7.3
     command:
-      [
-        '-b',
-        '0.0.0.0',
-        '-Dkeycloak.migration.action=import',
-        '-Dkeycloak.migration.provider=dir',
-        '-Dkeycloak.migration.dir=/opt/jboss/keycloak/realm-config',
-        '-Dkeycloak.migration.strategy=OVERWRITE_EXISTING',
-        '-Djboss.socket.binding.port-offset=1000',
-        '-Dkeycloak.profile.feature.upload_scripts=enabled',
-      ]
+      - start-dev
+      - --http-port=9080
+      - --http-relative-path=/auth
+      - --import-realm
     volumes:
-      - ./realm-config:/opt/jboss/keycloak/realm-config
+      - ./realm-config:/opt/keycloak/data/import
     environment:
-      - KEYCLOAK_USER=admin
-      - KEYCLOAK_PASSWORD=admin
-      - DB_VENDOR=h2
+      # KC_BOOTSTRAP_ADMIN_* is used from Keycloak 26; KEYCLOAK_ADMIN_* is kept for older tags
+      - KC_BOOTSTRAP_ADMIN_USERNAME=admin
+      - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=admin
     ports:
       - 9080:9080
       - 9443:9443
-      - 10990:10990

--- a/src/main/docker/realm-config/jhipster-realm.json
+++ b/src/main/docker/realm-config/jhipster-realm.json
@@ -694,17 +694,6 @@
         ],
         "policies": [
           {
-            "id": "ff09b194-0615-4cfd-9851-74adf540dabd",
-            "name": "Default Policy",
-            "description": "A policy that grants access only for users within this realm",
-            "type": "js",
-            "logic": "POSITIVE",
-            "decisionStrategy": "AFFIRMATIVE",
-            "config": {
-              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
-            }
-          },
-          {
             "id": "4b5c72cc-b8b8-4bfc-95ac-61815669f985",
             "name": "Default Permission",
             "description": "A permission that applies to the default resource type",
@@ -712,8 +701,7 @@
             "logic": "POSITIVE",
             "decisionStrategy": "UNANIMOUS",
             "config": {
-              "defaultResourceType": "urn:internal:resources:default",
-              "applyPolicies": "[\"Default Policy\"]"
+              "defaultResourceType": "urn:internal:resources:default"
             }
           }
         ],


### PR DESCRIPTION
Fixes #228

`src/main/docker/keycloak.yml` pins `jboss/keycloak:11.0.1`, and that image no longer exists — Docker Hub returns `object not found` for the whole `jboss/keycloak` repository. The compose file, `npm run docker:keycloak:up` and every `*-oauth2` job in the CI matrix currently fail at image pull, before anything is exercised.

Repointing the image on its own is not sufficient. The realm export carries a `js`-type authorization policy on the `internal` client, which is what the current `-Dkeycloak.profile.feature.upload_scripts=enabled` flag existed to permit. Keycloak removed that feature in 18, so a modern server imports the realm and then exits:

```
INFO  Realm 'jhipster' imported
ERROR ERROR: Failed to start server in (development) mode
ERROR ERROR: Script upload is disabled
```

That policy is Keycloak's auto-generated default (`$evaluation.grant();` — grants everything unconditionally), so it is removed here along with the now-dangling `applyPolicies` reference from `Default Permission`. Effective authorization behaviour is unchanged.

`--http-relative-path=/auth` keeps the issuer URI that `application.yml` already expects, so no application configuration changes.

## Changes

- `src/main/docker/keycloak.yml` — `quay.io/keycloak/keycloak:26.7.3`, Quarkus-style `start-dev` arguments, realm mounted at `/opt/keycloak/data/import`. The WildFly-only `DB_VENDOR` and the `10990` management port are dropped; both admin env var forms are kept so older tags still work.
- `src/main/docker/realm-config/jhipster-realm.json` — 12-line removal of the `js` policy plus the reference to it.

## Verification

Run against this repository's own `realm-config` on `quay.io/keycloak/keycloak` 22.0.5 and 26.7.3:

```
removed js policies: [('internal', 'Default Policy')]
realm served at /auth after 6 attempts
issuer = http://localhost:9080/auth/realms/jhipster
```

Both versions import the realm and users, start cleanly, and serve the realm under the existing `/auth` path.

I have not run the full `*-oauth2` CI matrix end to end, so if those jobs depend on anything else from the old WildFly image I would want to hear it. Pinning 26.7.3 is a choice rather than a requirement — 22.0.5 works equally well if you would prefer to move in smaller steps.

## Relevance to #174

Keycloak 11 predates `mtls_endpoint_aliases`, so the bundled environment never advertised the member whose parsing #174 reports, which is part of why that issue has been hard to confirm locally. On a current server the discovery document does advertise it, which makes the reported failure reproducible in this project's own setup.
