### PR TITLE
fix: repair the webapp build after the webpack 5.76 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "tslint-config-prettier": "1.18.0",
         "tslint-eslint-rules": "5.4.0",
         "tslint-loader": "3.6.0",
-        "typescript": "4.1.5",
+        "typescript": "^4.3.5",
         "url-loader": "4.1.1",
         "vue-jest": "3.0.7",
         "vue-loader": "^15.11.1",
@@ -30383,9 +30383,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -58598,9 +58598,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "jhipster-control-center",
       "version": "0.0.4-SNAPSHOT",
       "license": "UNLICENSED",
       "dependencies": {
@@ -90,7 +91,7 @@
         "typescript": "4.1.5",
         "url-loader": "4.1.1",
         "vue-jest": "3.0.7",
-        "vue-loader": "15.9.6",
+        "vue-loader": "^15.11.1",
         "vue-template-compiler": "2.6.12",
         "wait-on": "5.2.1",
         "webpack": "5.76.0",
@@ -31066,9 +31067,9 @@
       }
     },
     "node_modules/vue-loader": {
-      "version": "15.9.6",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.6.tgz",
-      "integrity": "sha512-j0cqiLzwbeImIC6nVIby2o/ABAWhlppyL/m5oJ67R5MloP0hj/DtFgb0Zmq3J9CG7AJ+AXIvHVnJAPBvrLyuDg==",
+      "version": "15.11.1",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.11.1.tgz",
+      "integrity": "sha512-0iw4VchYLePqJfJu9s62ACWUXeSqM30SQqlIftbYWM3C+jpPcEHKSPUZBLjSF9au4HTHQ/naF6OGnO3Q/qGR3Q==",
       "dev": true,
       "dependencies": {
         "@vue/component-compiler-utils": "^3.1.0",
@@ -31076,6 +31077,21 @@
         "loader-utils": "^1.1.0",
         "vue-hot-reload-api": "^2.3.0",
         "vue-style-loader": "^4.1.0"
+      },
+      "peerDependencies": {
+        "css-loader": "*",
+        "webpack": "^3.0.0 || ^4.1.0 || ^5.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "cache-loader": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vue-template-compiler": {
+          "optional": true
+        }
       }
     },
     "node_modules/vue-loader/node_modules/hash-sum": {
@@ -59142,9 +59158,9 @@
       }
     },
     "vue-loader": {
-      "version": "15.9.6",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.6.tgz",
-      "integrity": "sha512-j0cqiLzwbeImIC6nVIby2o/ABAWhlppyL/m5oJ67R5MloP0hj/DtFgb0Zmq3J9CG7AJ+AXIvHVnJAPBvrLyuDg==",
+      "version": "15.11.1",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.11.1.tgz",
+      "integrity": "sha512-0iw4VchYLePqJfJu9s62ACWUXeSqM30SQqlIftbYWM3C+jpPcEHKSPUZBLjSF9au4HTHQ/naF6OGnO3Q/qGR3Q==",
       "dev": true,
       "requires": {
         "@vue/component-compiler-utils": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "typescript": "4.1.5",
     "url-loader": "4.1.1",
     "vue-jest": "3.0.7",
-    "vue-loader": "15.9.6",
+    "vue-loader": "^15.11.1",
     "vue-template-compiler": "2.6.12",
     "wait-on": "5.2.1",
     "webpack": "5.76.0",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "tslint-config-prettier": "1.18.0",
     "tslint-eslint-rules": "5.4.0",
     "tslint-loader": "3.6.0",
-    "typescript": "4.1.5",
+    "typescript": "^4.3.5",
     "url-loader": "4.1.1",
     "vue-jest": "3.0.7",
     "vue-loader": "^15.11.1",

--- a/src/main/webapp/app/router/index.ts
+++ b/src/main/webapp/app/router/index.ts
@@ -9,8 +9,8 @@ import Router from 'vue-router';
 import { Authority } from '@/shared/security/authority';
 const Home = () => import('@/core/home/home.vue');
 const Error = () => import('@/core/error/error.vue');
-import entities from '@/router/entities.ts';
-import pages from '@/router/pages.ts';
+import entities from '@/router/entities';
+import pages from '@/router/pages';
 
 // jhcc-custom begin
 const InstanceComponent = () => import('../applications/instance/instance.vue');

--- a/src/test/javascript/spec/app/shared/refresh/refresh-selector.mixin.spec.ts
+++ b/src/test/javascript/spec/app/shared/refresh/refresh-selector.mixin.spec.ts
@@ -1,9 +1,9 @@
 import { createLocalVue, shallowMount, Wrapper } from '@vue/test-utils';
 import * as config from '@/shared/config/config';
 import { BootstrapVue } from 'bootstrap-vue';
-import RefreshSelectorMixinClass from '@/shared/refresh/refresh-selector.mixin.ts';
+import RefreshSelectorMixinClass from '@/shared/refresh/refresh-selector.mixin';
 import RefreshSelectorMixinVue from '@/shared/refresh/refresh-selector.mixin.vue';
-import { RefreshService } from '@/shared/refresh/refresh.service.ts';
+import { RefreshService } from '@/shared/refresh/refresh.service';
 import { Observable } from 'rxjs';
 
 const localVue = createLocalVue();

--- a/src/test/javascript/spec/app/shared/routes/routes.component.spec.ts
+++ b/src/test/javascript/spec/app/shared/routes/routes.component.spec.ts
@@ -4,7 +4,7 @@ import { BootstrapVue } from 'bootstrap-vue';
 import RoutesSelectorVue from '@/shared/routes/routes-selector.vue';
 import RoutesSelectorClass from '@/shared/routes/routes-selector.component';
 import RoutesService from '@/shared/routes/routes.service';
-import { RefreshService } from '@/shared/refresh/refresh.service.ts';
+import { RefreshService } from '@/shared/refresh/refresh.service';
 import { Observable, throwError } from 'rxjs';
 import { jhcc_route, routes, service_test_route } from '../../../fixtures/jhcc.fixtures';
 


### PR DESCRIPTION
The webapp build currently fails on `main`, which fails the `Run backend test` step in **every** job of the CI matrix — including `jhcc-default`, `jhcc-static`, `jhcc-eureka` and `jhcc-consul`, because `ci:backend:test` runs the webapp build during `generate-resources`.

Three things are needed to get it compiling again. Each was identified by fixing the previous one and seeing what surfaced next.

### 1. `vue-loader` cannot load under webpack 5.76

```
[webpack-cli] Failed to load .../webpack/webpack.dev.js config
[webpack-cli] Error: Cannot find module 'webpack/lib/rules/DescriptionDataMatcherRulePlugin'
Require stack:
- node_modules/vue-loader/lib/plugin-webpack5.js
```

`vue-loader` 15.9.6 detects webpack 5, loads `plugin-webpack5.js`, and that requires a module which is not present in webpack 5.76.0. The bump in #188 moved webpack past what this `vue-loader` supports. 15.11.1 no longer requires it.

### 2. TypeScript 4.1.5 cannot parse webpack 5.76's bundled types

With the loader fixed, the dev build passes and the **production** build fails instead, with 267 errors of this shape:

```
ERROR in node_modules/webpack/types.d.ts:6701:6
TS1005: ';' expected.
  > 6701 | 	get outputOptions(): Output;
```

These are parse errors rather than type errors, so the existing `skipLibCheck: true` does not suppress them. TypeScript 4.3.5 parses the file.

I checked 4.9.5 as well and deliberately did not use it: it additionally reports `Property 'msSaveOrOpenBlob' does not exist on type 'Navigator'`, which would require unrelated source changes. 4.3.5 is the smallest version that fixes the parsing.

### 3. Five import specifiers ending in `.ts`

Once parsing works, TypeScript reports these as `TS2691`:

| file | count |
| --- | --- |
| `src/main/webapp/app/router/index.ts` | 2 |
| `src/test/javascript/spec/app/shared/refresh/refresh-selector.mixin.spec.ts` | 2 |
| `src/test/javascript/spec/app/shared/routes/routes.component.spec.ts` | 1 |

Dropping the extension is the fix TypeScript itself suggests. The neighbouring `.vue` specifier in the mixin spec is intentionally left alone.

## Result

Running the project's own CI matrix on this branch:

- `Run backend test` and `Package application` now pass in **all seven** jobs.
- `jhcc-default`, `jhcc-static` and `jhcc-eureka` pass completely.
- The remaining four jobs now fail at `Run e2e test`, a later step that needs the docker-compose services.

Three of those four are the `*-oauth2` jobs, and they fail because the application cannot reach Keycloak:

```
BeanCreationException: Error creating bean with name 'clientRegistrationRepository'
ResourceAccessException: I/O error on GET request for
  "http://localhost:9080/auth/realms/jhipster/.well-known/openid-configuration"
java.net.ConnectException: Connection refused
```

Keycloak is not running because its image cannot be pulled — that is #228, which #229 addresses. The CI script starts the compose file and sleeps rather than checking, so the pull failure does not surface until the application fails to start.

I have not established the cause of the fourth failure (`jhcc-consul`); its server also did not come up, but the log does not show why, and e2e on a fork is not a clean signal in any case.

So this PR fixes the build. It does not claim to make the whole matrix green on its own.

## Manifest changes

`package.json` and `package-lock.json` change exactly two resolved versions — `vue-loader` and `typescript`. The lockfile was regenerated with `npm install --package-lock-only` on npm 8 so `lockfileVersion: 2` is preserved; webpack itself is untouched at 5.76.0.
