### PR TITLE
Fix reactive OAuth2 startup with Keycloak mTLS discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,9 @@
         <archunit-junit5.version>0.15.0</archunit-junit5.version>
         <mapstruct.version>1.4.2.Final</mapstruct.version>
         <oauth2-client.version>2.3.1.RELEASE</oauth2-client.version>
+        <!-- Keep the Nimbus pair compatible when parsing Keycloak mTLS discovery metadata. -->
+        <oauth2-oidc-sdk.version>9.43.6</oauth2-oidc-sdk.version>
+        <nimbus-jose-jwt.version>9.37.4</nimbus-jose-jwt.version>
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -95,6 +98,16 @@
                 <version>${jhipster-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>oauth2-oidc-sdk</artifactId>
+                <version>${oauth2-oidc-sdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbus-jose-jwt.version}</version>
             </dependency>
             <!-- jhipster-needle-maven-add-dependency-management -->
         </dependencies>

--- a/src/test/java/tech/jhipster/controlcenter/config/OAuth2ClientDiscoveryTest.java
+++ b/src/test/java/tech/jhipster/controlcenter/config/OAuth2ClientDiscoveryTest.java
@@ -111,7 +111,15 @@ class OAuth2ClientDiscoveryTest {
             .run(
                 context -> {
                     assertThat(context).hasFailed();
-                    assertThat(context.getStartupFailure()).hasRootCauseInstanceOf(IllegalStateException.class);
+                    assertThat(context.getStartupFailure())
+                        .hasRootCauseInstanceOf(IllegalStateException.class)
+                        .hasRootCauseMessage(
+                            "The Issuer \"" +
+                            issuer +
+                            "/different\" provided in the configuration metadata did not match the requested issuer \"" +
+                            issuer +
+                            "\""
+                        );
                     assertThat(discoveryRequests.get()).isPositive();
                 }
             );

--- a/src/test/java/tech/jhipster/controlcenter/config/OAuth2ClientDiscoveryTest.java
+++ b/src/test/java/tech/jhipster/controlcenter/config/OAuth2ClientDiscoveryTest.java
@@ -1,0 +1,119 @@
+package tech.jhipster.controlcenter.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.security.oauth2.client.reactive.ReactiveOAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+
+class OAuth2ClientDiscoveryTest {
+
+    private HttpServer discoveryServer;
+    private String issuer;
+    private final AtomicInteger discoveryRequests = new AtomicInteger();
+    private Map<String, Object> metadata;
+
+    @BeforeEach
+    void serveProviderMetadata() throws Exception {
+        discoveryServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        issuer = "http://127.0.0.1:" + discoveryServer.getAddress().getPort() + "/auth/realms/jhipster";
+        metadata = new LinkedHashMap<>();
+        metadata.put("issuer", issuer);
+        metadata.put("authorization_endpoint", issuer + "/protocol/openid-connect/auth");
+        metadata.put("token_endpoint", issuer + "/protocol/openid-connect/token");
+        metadata.put("jwks_uri", issuer + "/protocol/openid-connect/certs");
+        metadata.put("response_types_supported", List.of("code"));
+        metadata.put("subject_types_supported", List.of("public"));
+        metadata.put("id_token_signing_alg_values_supported", List.of("RS256"));
+        discoveryServer.createContext(
+            "/auth/realms/jhipster/.well-known/openid-configuration",
+            exchange -> {
+                discoveryRequests.incrementAndGet();
+                byte[] response = new ObjectMapper().writeValueAsBytes(metadata);
+                exchange.getResponseHeaders().set("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, response.length);
+                try (java.io.OutputStream stream = exchange.getResponseBody()) {
+                    stream.write(response);
+                }
+            }
+        );
+        discoveryServer.start();
+    }
+
+    @AfterEach
+    void stopProvider() {
+        if (discoveryServer != null) {
+            discoveryServer.stop(0);
+        }
+    }
+
+    private ReactiveWebApplicationContextRunner clientContext() {
+        return new ReactiveWebApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(ReactiveSecurityAutoConfiguration.class, ReactiveOAuth2ClientAutoConfiguration.class))
+            .withPropertyValues(
+                "spring.security.oauth2.client.provider.oidc.issuer-uri=" + issuer,
+                "spring.security.oauth2.client.registration.oidc.client-id=web_app",
+                "spring.security.oauth2.client.registration.oidc.client-secret=web_app",
+                "spring.security.oauth2.client.registration.oidc.scope=openid,profile,email"
+            );
+    }
+
+    @Test
+    void startsReactiveClientWithMtlsDiscoveryMetadata() {
+        metadata.put("mtls_endpoint_aliases", Map.of("token_endpoint", issuer + "/mtls/token"));
+        assertClientStarts();
+    }
+
+    @Test
+    void startsReactiveClientWithoutMtlsDiscoveryMetadata() {
+        assertClientStarts();
+    }
+
+    private void assertClientStarts() {
+        clientContext()
+            .run(
+                context -> {
+                    assertThat(context).hasNotFailed().hasSingleBean(ReactiveClientRegistrationRepository.class);
+                    ClientRegistration client = context
+                        .getBean(ReactiveClientRegistrationRepository.class)
+                        .findByRegistrationId("oidc")
+                        .block(Duration.ofSeconds(5));
+                    assertThat(client).isNotNull();
+                    assertThat(client.getClientId()).isEqualTo("web_app");
+                    assertThat(client.getScopes()).containsExactlyInAnyOrder("openid", "profile", "email");
+                    assertThat(client.getProviderDetails().getIssuerUri()).isEqualTo(issuer);
+                    assertThat(client.getProviderDetails().getTokenUri()).isEqualTo(metadata.get("token_endpoint"));
+                    assertThat(client.getProviderDetails().getConfigurationMetadata().get("mtls_endpoint_aliases"))
+                        .isEqualTo(metadata.get("mtls_endpoint_aliases"));
+                    assertThat(discoveryRequests.get()).isPositive();
+                }
+            );
+    }
+
+    @Test
+    void rejectsDiscoveryForAnotherIssuer() {
+        metadata.put("issuer", issuer + "/different");
+        clientContext()
+            .run(
+                context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).hasRootCauseInstanceOf(IllegalStateException.class);
+                    assertThat(discoveryRequests.get()).isPositive();
+                }
+            );
+    }
+}


### PR DESCRIPTION
Fixes #174

OAuth2 startup fails when provider discovery contains `mtls_endpoint_aliases`: Spring's client-registration auto-configuration passes a nested map to the old Nimbus parser, which rejects it. This pins `oauth2-oidc-sdk` to 9.43.6 and `nimbus-jose-jwt` to the compatible 9.37.4 patch release.

The new regression starts Spring's reactive OAuth2 client auto-configuration against a local HTTP discovery endpoint and retrieves the generated `ReactiveClientRegistrationRepository` bean. It checks provider metadata and configured client/scopes, preserves support for providers without mTLS aliases, and checks the exact issuer-mismatch failure.

Validation on Java 11:

- Original dependencies: 3 new tests, 1 failure. The mTLS case reproduces `ParseException: Unexpected type of JSON object member with key mtls_endpoint_aliases` during client-registration bean creation; the other two cases pass.
- Fixed dependencies: `./mvnw -B -ntp -P-webapp verify` passes 33 unit and 18 integration tests, with no failures, errors, skipped tests, or Checkstyle violations.
- After tightening the issuer-error assertion, all 3 focused tests pass again. The new test passes repository-version Prettier.
- Real Keycloak 15.0.1 with this repository's exported test realm: the original-dependency jar fails during client registration with the reported mTLS metadata parsing error. The fixed jar starts, returns HTTP 200 / `UP` from `/management/health`, and redirects `/oauth2/authorization/oidc` to the Keycloak login page. [Validation details](https://github.com/jhipster/jhipster-control-center/pull/231#issuecomment-5589068547).

Credit: #208 and #227 already establish the Nimbus dependency-update approach, and #227 explains the nested-map trigger. This independently written test adds application-context/bean startup coverage. JWT 9.37.4 replaces 9.37.3 because [CVE-2025-53864](https://github.com/advisories/GHSA-xwmg-2g98-w7v9) is fixed in 9.37.4.

The automated regression uses an in-process HTTP fixture. Real-provider startup and authorization initiation were also verified; a complete browser login/callback was not verified. Existing nonfatal dependency-convergence warnings remain. Prepared with AI assistance and locally verified.

Submitted for consideration for the advertised #174 bounty; I understand acceptance and any award are at the maintainers' discretion.

— bountyhunter.1996