### PR TITLE
fix: handle Keycloak mtls_endpoint_aliases metadata (#174)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
         <blockhound-junit-platform.version>1.0.4.RELEASE</blockhound-junit-platform.version>
         <archunit-junit5.version>0.15.0</archunit-junit5.version>
         <mapstruct.version>1.4.2.Final</mapstruct.version>
-        <oauth2-client.version>2.3.1.RELEASE</oauth2-client.version>
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -288,7 +287,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
-            <version>${oauth2-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
         <blockhound-junit-platform.version>1.0.4.RELEASE</blockhound-junit-platform.version>
         <archunit-junit5.version>0.15.0</archunit-junit5.version>
         <mapstruct.version>1.4.2.Final</mapstruct.version>
+        <oauth2-client.version>2.3.1.RELEASE</oauth2-client.version>
+        <!-- Pinned together: oauth2-oidc-sdk 9.x tolerates a plain Map for a nested
+        discovery member (see #174), and it must be paired with the matching
+        nimbus-jose-jwt generation it is built against. -->
+        <oauth2-oidc-sdk.version>9.43.6</oauth2-oidc-sdk.version>
+        <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -94,6 +100,16 @@
                 <version>${jhipster-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>oauth2-oidc-sdk</artifactId>
+                <version>${oauth2-oidc-sdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbus-jose-jwt.version}</version>
             </dependency>
             <!-- jhipster-needle-maven-add-dependency-management -->
         </dependencies>
@@ -287,6 +303,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
+            <version>${oauth2-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/src/test/java/tech/jhipster/controlcenter/config/ClientRegistrationsMtlsAliasesTest.java
+++ b/src/test/java/tech/jhipster/controlcenter/config/ClientRegistrationsMtlsAliasesTest.java
@@ -1,0 +1,105 @@
+package tech.jhipster.controlcenter.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrations;
+
+/**
+ * End-to-end coverage for
+ * <a href="https://github.com/jhipster/jhipster-control-center/issues/174">#174</a> through the
+ * entry point that actually fails at startup.
+ *
+ * <p>{@code OidcMetadataMtlsAliasesTest} pins the parsing behaviour directly. This test drives
+ * {@link ClientRegistrations#fromIssuerLocation(String)}, the call that
+ * {@code ReactiveClientRegistrationRepository} makes on boot, against a discovery document served
+ * over HTTP. That path reads the document with Jackson into a {@code Map} and hands Nimbus a
+ * shallow {@code JSONObject} copy, which is what leaves {@code mtls_endpoint_aliases} as a
+ * {@code java.util.LinkedHashMap} and produces the reported failure.
+ */
+class ClientRegistrationsMtlsAliasesTest {
+
+    private HttpServer server;
+
+    private String issuer;
+
+    @BeforeEach
+    void startDiscoveryEndpoint() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        int port = server.getAddress().getPort();
+        issuer = "http://127.0.0.1:" + port + "/auth/realms/jhipster";
+
+        byte[] body = discoveryDocument(issuer).getBytes(StandardCharsets.UTF_8);
+        server.createContext(
+            "/auth/realms/jhipster/.well-known/openid-configuration",
+            exchange -> {
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, body.length);
+                try (OutputStream out = exchange.getResponseBody()) {
+                    out.write(body);
+                }
+            }
+        );
+        server.start();
+    }
+
+    @AfterEach
+    void stopDiscoveryEndpoint() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * A Keycloak-shaped discovery document. Single quotes are used for readability and swapped for
+     * JSON double quotes before returning.
+     */
+    private static String discoveryDocument(String issuer) {
+        StringBuilder json = new StringBuilder();
+        json.append("{");
+        json.append("'issuer': '").append(issuer).append("',");
+        json.append("'authorization_endpoint': '").append(issuer).append("/protocol/openid-connect/auth',");
+        json.append("'token_endpoint': '").append(issuer).append("/protocol/openid-connect/token',");
+        json.append("'userinfo_endpoint': '").append(issuer).append("/protocol/openid-connect/userinfo',");
+        json.append("'jwks_uri': '").append(issuer).append("/protocol/openid-connect/certs',");
+        json.append("'response_types_supported': ['code', 'id_token', 'token id_token'],");
+        json.append("'subject_types_supported': ['public', 'pairwise'],");
+        json.append("'id_token_signing_alg_values_supported': ['RS256'],");
+        json.append("'scopes_supported': ['openid', 'profile', 'email'],");
+        json.append("'mtls_endpoint_aliases': {");
+        json.append("'token_endpoint': '").append(issuer).append("/protocol/openid-connect/token/mtls',");
+        json.append("'authorization_endpoint': '").append(issuer).append("/protocol/openid-connect/auth/mtls'");
+        json.append("}");
+        json.append("}");
+        return json.toString().replace('\'', '"');
+    }
+
+    @Test
+    void buildsAClientRegistrationFromAKeycloakDiscoveryDocument() {
+        assertThatCode(() -> ClientRegistrations.fromIssuerLocation(issuer).clientId("web_app").clientSecret("secret").build())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void resolvesTheEndpointsTheApplicationNeeds() {
+        ClientRegistration registration = ClientRegistrations
+            .fromIssuerLocation(issuer)
+            .clientId("web_app")
+            .clientSecret("secret")
+            .build();
+
+        assertThat(registration.getProviderDetails().getIssuerUri()).isEqualTo(issuer);
+        assertThat(registration.getProviderDetails().getTokenUri()).isEqualTo(issuer + "/protocol/openid-connect/token");
+        assertThat(registration.getProviderDetails().getAuthorizationUri())
+            .isEqualTo(issuer + "/protocol/openid-connect/auth");
+        assertThat(registration.getProviderDetails().getJwkSetUri()).isEqualTo(issuer + "/protocol/openid-connect/certs");
+    }
+}

--- a/src/test/java/tech/jhipster/controlcenter/config/OidcMetadataMtlsAliasesTest.java
+++ b/src/test/java/tech/jhipster/controlcenter/config/OidcMetadataMtlsAliasesTest.java
@@ -6,6 +6,10 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import com.nimbusds.oauth2.sdk.as.AuthorizationServerEndpointMetadata;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -13,17 +17,20 @@ import org.junit.jupiter.api.Test;
  * <a href="https://github.com/jhipster/jhipster-control-center/issues/174">#174</a>.
  *
  * <p>Keycloak 12 and later advertise an {@code mtls_endpoint_aliases} object in their OpenID
- * Connect discovery document. On the {@code com.nimbusds:oauth2-oidc-sdk} 7.x line,
- * {@code JSONObjectUtils.getGeneric} rejects that member with
- * {@code ParseException: Unexpected type of JSON object member with key mtls_endpoint_aliases},
- * which aborts {@code ClientRegistrations.fromIssuerLocation} and stops the control center from
- * starting against a modern Keycloak.
+ * Connect discovery document, and the control center fails to start against them with
+ * {@code ParseException: Unexpected type of JSON object member with key mtls_endpoint_aliases}.
  *
- * <p>The 7.x line reaches this build through the OAuth2 client starter: Spring Boot 2.3.1
- * manages {@code oauth2-oidc-sdk} 7.1.1, whereas the Boot 2.4.x generation used by the rest of
- * the application manages 8.36. These tests drive the exact SDK entry point named in the
- * reported stack trace and assert that {@code mtls_endpoint_aliases} is not merely tolerated but
- * parsed and retained.
+ * <p>The failure depends on <em>how</em> the document reaches Nimbus, not on the document
+ * itself. {@code ClientRegistrations} does not hand Nimbus the raw JSON text: it reads the
+ * discovery document into a {@code Map} with Jackson and then calls
+ * {@code OIDCProviderMetadata.parse(new JSONObject(map))}. That constructor copies only the top
+ * level, so the nested {@code mtls_endpoint_aliases} value stays a {@code java.util.LinkedHashMap}
+ * rather than becoming a {@code net.minidev.json.JSONObject}. Older {@code oauth2-oidc-sdk}
+ * releases require that nested member to be a {@code JSONObject} exactly and reject the map.
+ *
+ * <p>This is why parsing the same document from a {@code String} always succeeds — the SDK's own
+ * parser produces {@code JSONObject} for nested members — and why the test below deliberately
+ * reproduces the shallow-map shape instead.
  */
 class OidcMetadataMtlsAliasesTest {
 
@@ -33,40 +40,56 @@ class OidcMetadataMtlsAliasesTest {
 
     private static final String MTLS_AUTHORIZATION_ENDPOINT = ISSUER + "/protocol/openid-connect/auth/mtls";
 
+    private static JSONArray array(String... values) {
+        JSONArray array = new JSONArray();
+        for (String value : values) {
+            array.add(value);
+        }
+        return array;
+    }
+
     /**
-     * Builds a trimmed but valid Keycloak discovery document. Single quotes are used purely for
-     * readability and swapped for JSON double quotes before returning.
+     * Builds the discovery document the way {@code ClientRegistrations} presents it to Nimbus:
+     * a top-level {@link JSONObject} shallow-copied from a Jackson map, whose nested
+     * {@code mtls_endpoint_aliases} member is still a plain {@link LinkedHashMap}.
      *
      * @param withMtlsAliases whether to advertise the {@code mtls_endpoint_aliases} object.
      */
-    private static String keycloakDiscoveryDocument(boolean withMtlsAliases) {
-        StringBuilder json = new StringBuilder();
-        json.append("{");
-        json.append("'issuer': '").append(ISSUER).append("',");
-        json.append("'authorization_endpoint': '").append(ISSUER).append("/protocol/openid-connect/auth',");
-        json.append("'token_endpoint': '").append(ISSUER).append("/protocol/openid-connect/token',");
-        json.append("'jwks_uri': '").append(ISSUER).append("/protocol/openid-connect/certs',");
-        json.append("'response_types_supported': ['code', 'id_token', 'token id_token'],");
-        json.append("'subject_types_supported': ['public', 'pairwise'],");
-        json.append("'id_token_signing_alg_values_supported': ['RS256']");
+    private static JSONObject discoveryDocumentAsSpringSecurityBuildsIt(boolean withMtlsAliases) {
+        Map<String, Object> document = new LinkedHashMap<>();
+        document.put("issuer", ISSUER);
+        document.put("authorization_endpoint", ISSUER + "/protocol/openid-connect/auth");
+        document.put("token_endpoint", ISSUER + "/protocol/openid-connect/token");
+        document.put("jwks_uri", ISSUER + "/protocol/openid-connect/certs");
+        document.put("response_types_supported", array("code", "id_token", "token id_token"));
+        document.put("subject_types_supported", array("public", "pairwise"));
+        document.put("id_token_signing_alg_values_supported", array("RS256"));
+
         if (withMtlsAliases) {
-            json.append(",'mtls_endpoint_aliases': {");
-            json.append("'token_endpoint': '").append(MTLS_TOKEN_ENDPOINT).append("',");
-            json.append("'authorization_endpoint': '").append(MTLS_AUTHORIZATION_ENDPOINT).append("'");
-            json.append("}");
+            Map<String, Object> aliases = new LinkedHashMap<>();
+            aliases.put("token_endpoint", MTLS_TOKEN_ENDPOINT);
+            aliases.put("authorization_endpoint", MTLS_AUTHORIZATION_ENDPOINT);
+            document.put("mtls_endpoint_aliases", aliases);
         }
-        json.append("}");
-        return json.toString().replace('\'', '"');
+
+        return new JSONObject(document);
     }
 
     @Test
-    void parsesDiscoveryDocumentContainingMtlsEndpointAliases() {
-        assertThatCode(() -> OIDCProviderMetadata.parse(keycloakDiscoveryDocument(true))).doesNotThrowAnyException();
+    void parsesMetadataWhenMtlsEndpointAliasesArrivesAsAPlainMap() {
+        JSONObject document = discoveryDocumentAsSpringSecurityBuildsIt(true);
+
+        assertThat(document.get("mtls_endpoint_aliases"))
+            .as("the nested member must stay a plain map to reproduce the reported failure")
+            .isInstanceOf(Map.class)
+            .isNotInstanceOf(JSONObject.class);
+
+        assertThatCode(() -> OIDCProviderMetadata.parse(document)).doesNotThrowAnyException();
     }
 
     @Test
     void retainsMtlsEndpointAliasesInsteadOfDiscardingThem() throws Exception {
-        OIDCProviderMetadata metadata = OIDCProviderMetadata.parse(keycloakDiscoveryDocument(true));
+        OIDCProviderMetadata metadata = OIDCProviderMetadata.parse(discoveryDocumentAsSpringSecurityBuildsIt(true));
 
         assertThat(metadata.getIssuer().getValue()).isEqualTo(ISSUER);
 
@@ -78,7 +101,7 @@ class OidcMetadataMtlsAliasesTest {
 
     @Test
     void stillParsesDiscoveryDocumentWithoutMtlsEndpointAliases() throws Exception {
-        OIDCProviderMetadata metadata = OIDCProviderMetadata.parse(keycloakDiscoveryDocument(false));
+        OIDCProviderMetadata metadata = OIDCProviderMetadata.parse(discoveryDocumentAsSpringSecurityBuildsIt(false));
 
         assertThat(metadata.getIssuer().getValue()).isEqualTo(ISSUER);
         assertThat(metadata.getMtlsEndpointAliases()).isNull();

--- a/src/test/java/tech/jhipster/controlcenter/config/OidcMetadataMtlsAliasesTest.java
+++ b/src/test/java/tech/jhipster/controlcenter/config/OidcMetadataMtlsAliasesTest.java
@@ -1,0 +1,86 @@
+package tech.jhipster.controlcenter.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.nimbusds.oauth2.sdk.as.AuthorizationServerEndpointMetadata;
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for
+ * <a href="https://github.com/jhipster/jhipster-control-center/issues/174">#174</a>.
+ *
+ * <p>Keycloak 12 and later advertise an {@code mtls_endpoint_aliases} object in their OpenID
+ * Connect discovery document. On the {@code com.nimbusds:oauth2-oidc-sdk} 7.x line,
+ * {@code JSONObjectUtils.getGeneric} rejects that member with
+ * {@code ParseException: Unexpected type of JSON object member with key mtls_endpoint_aliases},
+ * which aborts {@code ClientRegistrations.fromIssuerLocation} and stops the control center from
+ * starting against a modern Keycloak.
+ *
+ * <p>The 7.x line reaches this build through the OAuth2 client starter: Spring Boot 2.3.1
+ * manages {@code oauth2-oidc-sdk} 7.1.1, whereas the Boot 2.4.x generation used by the rest of
+ * the application manages 8.36. These tests drive the exact SDK entry point named in the
+ * reported stack trace and assert that {@code mtls_endpoint_aliases} is not merely tolerated but
+ * parsed and retained.
+ */
+class OidcMetadataMtlsAliasesTest {
+
+    private static final String ISSUER = "http://keycloak:9080/auth/realms/jhipster";
+
+    private static final String MTLS_TOKEN_ENDPOINT = ISSUER + "/protocol/openid-connect/token/mtls";
+
+    private static final String MTLS_AUTHORIZATION_ENDPOINT = ISSUER + "/protocol/openid-connect/auth/mtls";
+
+    /**
+     * Builds a trimmed but valid Keycloak discovery document. Single quotes are used purely for
+     * readability and swapped for JSON double quotes before returning.
+     *
+     * @param withMtlsAliases whether to advertise the {@code mtls_endpoint_aliases} object.
+     */
+    private static String keycloakDiscoveryDocument(boolean withMtlsAliases) {
+        StringBuilder json = new StringBuilder();
+        json.append("{");
+        json.append("'issuer': '").append(ISSUER).append("',");
+        json.append("'authorization_endpoint': '").append(ISSUER).append("/protocol/openid-connect/auth',");
+        json.append("'token_endpoint': '").append(ISSUER).append("/protocol/openid-connect/token',");
+        json.append("'jwks_uri': '").append(ISSUER).append("/protocol/openid-connect/certs',");
+        json.append("'response_types_supported': ['code', 'id_token', 'token id_token'],");
+        json.append("'subject_types_supported': ['public', 'pairwise'],");
+        json.append("'id_token_signing_alg_values_supported': ['RS256']");
+        if (withMtlsAliases) {
+            json.append(",'mtls_endpoint_aliases': {");
+            json.append("'token_endpoint': '").append(MTLS_TOKEN_ENDPOINT).append("',");
+            json.append("'authorization_endpoint': '").append(MTLS_AUTHORIZATION_ENDPOINT).append("'");
+            json.append("}");
+        }
+        json.append("}");
+        return json.toString().replace('\'', '"');
+    }
+
+    @Test
+    void parsesDiscoveryDocumentContainingMtlsEndpointAliases() {
+        assertThatCode(() -> OIDCProviderMetadata.parse(keycloakDiscoveryDocument(true))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void retainsMtlsEndpointAliasesInsteadOfDiscardingThem() throws Exception {
+        OIDCProviderMetadata metadata = OIDCProviderMetadata.parse(keycloakDiscoveryDocument(true));
+
+        assertThat(metadata.getIssuer().getValue()).isEqualTo(ISSUER);
+
+        AuthorizationServerEndpointMetadata aliases = metadata.getMtlsEndpointAliases();
+        assertThat(aliases).as("mtls_endpoint_aliases must be parsed, not skipped").isNotNull();
+        assertThat(aliases.getTokenEndpointURI()).isEqualTo(URI.create(MTLS_TOKEN_ENDPOINT));
+        assertThat(aliases.getAuthorizationEndpointURI()).isEqualTo(URI.create(MTLS_AUTHORIZATION_ENDPOINT));
+    }
+
+    @Test
+    void stillParsesDiscoveryDocumentWithoutMtlsEndpointAliases() throws Exception {
+        OIDCProviderMetadata metadata = OIDCProviderMetadata.parse(keycloakDiscoveryDocument(false));
+
+        assertThat(metadata.getIssuer().getValue()).isEqualTo(ISSUER);
+        assertThat(metadata.getMtlsEndpointAliases()).isNull();
+    }
+}


### PR DESCRIPTION
Fixes #174

## Summary
JHipster Control Center can fail during OIDC discovery against Keycloak 12+ / 15 when `mtls_endpoint_aliases` reaches Nimbus through Spring Security's shallow Map conversion. The old dependency set rejects the nested `LinkedHashMap` instead of accepting it as JSON metadata.

This branch keeps the fix and its reproducer together:
- pin `oauth2-oidc-sdk` to 9.43.6
- pin generation-compatible `nimbus-jose-jwt` to patched 9.37.4
- update the development Keycloak image to 15.0.2 so the bundled environment exposes the reported metadata shape
- add direct metadata and `ClientRegistrations.fromIssuerLocation(...)` regressions for the shallow-Map path

The tests assert that the reproducing nested value is a plain Java `Map` before Nimbus parses it, preventing a false-positive String-JSON test path.

Current source fence: upstream `main@a8e84d3addc29075849bc43b31e0e656b8a09926`; head `8dedbe72532034824187a9ea108aa51b96132fff`; compare is 7 ahead / 0 behind with exactly four changed paths (`pom.xml`, `src/main/docker/keycloak.yml`, and two OIDC regression classes). No exact-head hosted workflow is currently registered, so this submission does not claim fresh CI green.

This replaces the accidentally auto-closed unmerged #227 after its shared head was temporarily reset; the restored source branch is the intended carrier.